### PR TITLE
Turn off validation  for reset password

### DIFF
--- a/frontend/models/ResetPasswordForm.php
+++ b/frontend/models/ResetPasswordForm.php
@@ -60,6 +60,6 @@ class ResetPasswordForm extends Model
         $user->setPassword($this->password);
         $user->removePasswordResetToken();
 
-        return $user->save();
+        return $user->save(false);
     }
 }


### PR DESCRIPTION
No need validation `user` model for reset action. Validation occurs in the `this` model.