### PR TITLE
Added "skipFiles" functionality to the init command.

### DIFF
--- a/environments/index.php
+++ b/environments/index.php
@@ -9,6 +9,9 @@
  * return [
  *     'environment name' => [
  *         'path' => 'directory storing the local files',
+ *         'skipFiles'  => [
+ *             // list of files that should only copied once and skipped if they already exist
+ *         ],
  *         'setWritable' => [
  *             // list of directories that should be set writable
  *         ],

--- a/init
+++ b/init
@@ -65,6 +65,11 @@ if (empty($params['env'])) {
 
 echo "\n  Start initialization ...\n\n";
 $files = getFileList("$root/environments/{$env['path']}");
+if (isset($env['skipFiles'])) {
+    $skipFiles = $env['skipFiles'];
+    array_walk($skipFiles, function(&$value) use($env, $root) { $value = "$root/$value"; });
+    $files = array_diff($files, array_intersect_key($env['skipFiles'], array_filter($skipFiles, 'file_exists')));
+}
 $all = false;
 foreach ($files as $file) {
     if (!copyFile($root, "environments/{$env['path']}/$file", $file, $all, $params)) {


### PR DESCRIPTION
This allows you to specify files that should only be copied if the target doesn't exist yet and be skipped if it does.

You can use this functionality to not overwrite files that you manually edited directly in the folder (eg. if you wish to keep your database passwords completely out of your source control and fill them in after deploy on the server). This will prevent you having to do this each time the regular configuration changes and you have to run ./init again