### PR TITLE
Changed \common\models\LoginForm::getUser from public to private

### DIFF
--- a/common/models/LoginForm.php
+++ b/common/models/LoginForm.php
@@ -67,7 +67,7 @@ class LoginForm extends Model
      *
      * @return User|null
      */
-    public function getUser()
+    private function getUser()
     {
         if ($this->_user === false) {
             $this->_user = User::findByUsername($this->username);


### PR DESCRIPTION
Its implemented for caching user model only (to not make double query), its not part of public api.