### PR TITLE
Additional "email" rule for signup form model

### DIFF
--- a/frontend/models/SignupForm.php
+++ b/frontend/models/SignupForm.php
@@ -28,6 +28,7 @@ class SignupForm extends Model
             ['email', 'filter', 'filter' => 'trim'],
             ['email', 'required'],
             ['email', 'email'],
+            ['email', 'string', 'max' => 255],
             ['email', 'unique', 'targetClass' => '\common\models\User', 'message' => 'This email address has already been taken.'],
 
             ['password', 'required'],


### PR DESCRIPTION
Without that rule trying to sign up will cause database exception or email right trim depends on db server settings when email length > 255 and <320 (covered by email validator) characters.