### PR TITLE
Changed \common\models\LoginForm::getUser from private to protected

### DIFF
--- a/common/models/LoginForm.php
+++ b/common/models/LoginForm.php
@@ -67,7 +67,7 @@ class LoginForm extends Model
      *
      * @return User|null
      */
-    private function getUser()
+    protected function getUser()
     {
         if ($this->_user === null) {
             $this->_user = User::findByUsername($this->username);


### PR DESCRIPTION
@cebe, @samdark Guys, sorry for boring, last time we changed it from public to private and this was right by reasons posted inside previous PR around it. But it should be protected, because this method may be interested inside children classes.