### PR TITLE
Add minimal width to grid column filter inputs

### DIFF
--- a/backend/web/css/site.css
+++ b/backend/web/css/site.css
@@ -76,6 +76,11 @@ a.desc:after {
     white-space: nowrap;
 }
 
+.grid-view .filters input,
+.grid-view .filters select {
+    min-width: 50px;
+}
+
 .hint-block {
     display: block;
     margin-top: 5px;

--- a/frontend/web/css/site.css
+++ b/frontend/web/css/site.css
@@ -76,6 +76,11 @@ a.desc:after {
     white-space: nowrap;
 }
 
+.grid-view .filters input,
+.grid-view .filters select {
+    min-width: 50px;
+}
+
 .hint-block {
     display: block;
     margin-top: 5px;


### PR DESCRIPTION
[Fixed yii2 issue #8787](https://github.com/yiisoft/yii2/issues/8787)

Add minimal width to grid view filter inputs. This will avoid collapsing input field in a form with a large number of columns.