### PR TITLE
Update start-installation.md

### DIFF
--- a/docs/guide/start-installation.md
+++ b/docs/guide/start-installation.md
@@ -12,7 +12,7 @@ If you do not have [Composer](http://getcomposer.org/), follow the instructions 
 
 With Composer installed, you can then install the application using the following commands:
 
-    composer global require "fxp/composer-asset-plugin:~1.1.0"
+    composer global require "fxp/composer-asset-plugin:~1.1.1"
     composer create-project --prefer-dist yiisoft/yii2-app-advanced yii-application
 
 The first command installs the [composer asset plugin](https://github.com/francoispluchino/composer-asset-plugin/)


### PR DESCRIPTION
https://github.com/francoispluchino/composer-asset-plugin/releases/tag/v1.1.1 doesn't force composer to throw deprecation messages:
```
Deprecation Notice: The Composer\Package\LinkConstraint\MultiConstraint class is deprecated, use Composer\Semver\Constraint\MultiConstraint instead. in phar:///usr/local/bin/composer/src/Composer/Package/LinkConstraint/MultiConstraint.php:17
Deprecation Notice: The Composer\Package\LinkConstraint\LinkConstraintInterface interface is deprecated, use Composer\Semver\Constraint\ConstraintInterface instead. in phar:///usr/local/bin/composer/src/Composer/Package/LinkConstraint/LinkConstraintInterface.php:17
```