### PR TITLE
Upgrade codeception in tests/README.md

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ After creating and setting up the advanced application, follow these steps to pr
 1. Install Codeception if it's not yet installed:
 
    ```
-   composer global require "codeception/codeception=2.0.*" "codeception/specify=*" "codeception/verify=*"
+   composer global require "codeception/codeception=2.1.*" "codeception/specify=*" "codeception/verify=*"
    ```
 
    If you've never used Composer for global packages run `composer global status`. It should output:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

Before:
```
tests/codeception/common$ codecept build                                                                                
Building Actor classes for suites: unit
tests\codeception\common\UnitTester includes modules: 
PHP Fatal error:  Call to undefined method Codeception\Lib\Generator\Actor::getNumMethods() in /Users/bazilio/.composer/vendor/codeception/codeception/src/Codeception/Command/Build.php on line 74
PHP Stack trace:
PHP   1. {main}() /Users/bazilio/.composer/vendor/codeception/codeception/codecept:0
PHP   2. Symfony\Component\Console\Application->run() /Users/bazilio/.composer/vendor/codeception/codeception/codecept:27
PHP   3. Symfony\Component\Console\Application->doRun() /Users/bazilio/.composer/vendor/symfony/console/Application.php:123
PHP   4. Symfony\Component\Console\Application->doRunCommand() /Users/bazilio/.composer/vendor/symfony/console/Application.php:192
PHP   5. Symfony\Component\Console\Command\Command->run() /Users/bazilio/.composer/vendor/symfony/console/Application.php:844
PHP   6. Codeception\Command\Build->execute() /Users/bazilio/.composer/vendor/symfony/console/Command/Command.php:259
PHP   7. Codeception\Command\Build->buildActorsForConfig() /Users/bazilio/.composer/vendor/codeception/codeception/src/Codeception/Command/Build.php:46
```
After:
```
tests/codeception/common$ codecept build 
Building Actor classes for suites: unit
 -> UnitTesterActions.php generated successfully. 0 methods added
tests\codeception\common\UnitTester includes modules: 
UnitTester.php created.
```

php -v
```
PHP 5.6.16 (cli) (built: Nov 27 2015 10:28:34) 
Copyright (c) 1997-2015 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
    with Xdebug v2.2.7, Copyright (c) 2002-2015, by Derick Rethans
    with blackfire v1.7.0, https://blackfire.io, by Blackfireio Inc.
```

