### PR TITLE
Add post install application initialization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,8 @@
             "npm-asset-library": "vendor/npm",
             "bower-asset-library": "vendor/bower"
         }
+    },
+    "scripts": {
+        "post-install-cmd": "php init --env=Development --overwrite=n"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

I think we can make yii2 installation process a lot easier, if the initiation will be done automatically after composer dependencies are installed. Today, as a newbie in Yii I spent a lot of time figuring out why my application is not working, that was because in was not initialized after dependencies have been installed.

However, automatical execution of this command after `composer install` will not be harmful, since it will not overwrite the existent configuration.