### PR TITLE
Removed `$application` variable for consistence with `index-test.php`

### DIFF
--- a/environments/dev/backend/web/index.php
+++ b/environments/dev/backend/web/index.php
@@ -14,5 +14,4 @@ $config = yii\helpers\ArrayHelper::merge(
     require(__DIR__ . '/../config/main-local.php')
 );
 
-$application = new yii\web\Application($config);
-$application->run();
+(new yii\web\Application($config))->run();

--- a/environments/dev/frontend/web/index.php
+++ b/environments/dev/frontend/web/index.php
@@ -14,5 +14,4 @@ $config = yii\helpers\ArrayHelper::merge(
     require(__DIR__ . '/../config/main-local.php')
 );
 
-$application = new yii\web\Application($config);
-$application->run();
+(new yii\web\Application($config))->run();

--- a/environments/prod/backend/web/index.php
+++ b/environments/prod/backend/web/index.php
@@ -14,5 +14,4 @@ $config = yii\helpers\ArrayHelper::merge(
     require(__DIR__ . '/../config/main-local.php')
 );
 
-$application = new yii\web\Application($config);
-$application->run();
+(new yii\web\Application($config))->run();

--- a/environments/prod/frontend/web/index.php
+++ b/environments/prod/frontend/web/index.php
@@ -14,5 +14,4 @@ $config = yii\helpers\ArrayHelper::merge(
     require(__DIR__ . '/../config/main-local.php')
 );
 
-$application = new yii\web\Application($config);
-$application->run();
+(new yii\web\Application($config))->run();


### PR DESCRIPTION
Eliminated inconsistency of `index.php`:
```PHP
$application = new common\components\WebApp($config);
$application->run();
```
versus `index-test.php`:
```PHP
(new yii\web\Application($config))->run();
```

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -
