### PR TITLE
Fix for acceptance test.

### DIFF
--- a/frontend/tests/acceptance/HomeCest.php
+++ b/frontend/tests/acceptance/HomeCest.php
@@ -11,8 +11,11 @@ class HomeCest
     {
         $I->amOnPage(Url::toRoute('/site/index'));
         $I->see('My Company');
+
         $I->seeLink('About');
         $I->click('About');
+        $I->wait(2); // wait for page to be opened
+
         $I->see('This is the About page.');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Acceptance test HomeCest fails for me on step `$I->see('This is the About page.');`. This PR fixes it in same manner as in https://github.com/yiisoft/yii2-app-basic/blob/master/tests/acceptance/HomeCest.php.