### PR TITLE
apache acl (2.2, 2.4)

### DIFF
--- a/docs/guide/start-installation.md
+++ b/docs/guide/start-installation.md
@@ -74,6 +74,12 @@ the installed application. You only need to do these once for all.
                DirectoryIndex index.php
 
                # ...other settings...
+               # Apache 2.4
+               Require all granted
+               
+               ## Apache 2.2
+               # Order allow,deny
+               # Allow from all
            </Directory>
        </VirtualHost>
        
@@ -94,6 +100,12 @@ the installed application. You only need to do these once for all.
                DirectoryIndex index.php
 
                # ...other settings...
+               # Apache 2.4
+               Require all granted
+               
+               ## Apache 2.2
+               # Order allow,deny
+               # Allow from all
            </Directory>
        </VirtualHost>
    ```


### PR DESCRIPTION
In 2.2, access control based on client hostname, IP address, and other characteristics of client requests was done using the directives Order, Allow, Deny, and Satisfy.

In 2.4, such access control is done in the same way as other authorization checks, using the new module mod_authz_host.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
