### PR TITLE
composer-asset-plugin v1.3.0 Release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
         "codeception/verify": "~0.3.1"
     },
     "config": {
-        "process-timeout": 1800
-    },
-    "extra": {
-        "asset-installer-paths": {
-            "npm-asset-library": "vendor/npm",
-            "bower-asset-library": "vendor/bower"
+        "process-timeout": 1800,
+        "fxp-asset": {
+            "installer-paths": {
+                "npm-asset-library": "vendor/npm",
+                "bower-asset-library": "vendor/bower"
+            }
         }
     },
     "scripts": {


### PR DESCRIPTION
The "extra.asset-installer-paths" option is deprecated, use the "config.fxp-asset.installer-paths" option

#243

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes/no
| Fixed issues  | #243 
