### PR TITLE
Fix composer deprecated msg.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
         "codeception/verify": "~0.3.1"
     },
     "config": {
-        "process-timeout": 1800
-    },
-    "extra": {
-        "asset-installer-paths": {
-            "npm-asset-library": "vendor/npm",
-            "bower-asset-library": "vendor/bower"
+        "process-timeout": 1800,
+        "fxp-asset":{
+            "installer-paths": {
+                "npm-asset-library": "vendor/npm",
+                "bower-asset-library": "vendor/bower"
+            }
         }
     },
     "scripts": {


### PR DESCRIPTION
The "extra.asset-installer-paths" option is deprecated, use the "config.fxp-asset.installer-paths" option