### PR TITLE
faster composer update & memory limit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "config": {
         "process-timeout": 1800,
         "fxp-asset":{
+            "pattern-skip-version": "(-build|-patch)",
             "installer-paths": {
                 "npm-asset-library": "vendor/npm",
                 "bower-asset-library": "vendor/bower"


### PR DESCRIPTION
when I require some extension, composer take some hours. I waited for 5 hours and it's not done yet then stopped with fatal error of memory limit. Then I try this and it's working

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
#243 should be fixed already even before this PR