### PR TITLE
Remove remote host on xdebug configuration

### DIFF
--- a/vagrant/provision/once-as-root.sh
+++ b/vagrant/provision/once-as-root.sh
@@ -48,7 +48,7 @@ sed -i 's/owner = www-data/owner = vagrant/g' /etc/php/7.0/fpm/pool.d/www.conf
 cat << EOF > /etc/php/7.0/mods-available/xdebug.ini
 zend_extension=xdebug.so
 xdebug.remote_enable=1
-xdebug.remote_host=192.168.88.1
+xdebug.remote_connect_back=1
 xdebug.remote_port=9000
 xdebug.remote_autostart=1
 EOF


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | #282 

Remove remote host on xdebug configuration and add remote connect back
