### PR TITLE
add specific cache components

### DIFF
--- a/common/config/main.php
+++ b/common/config/main.php
@@ -9,5 +9,13 @@ return [
         'cache' => [
             'class' => 'yii\caching\FileCache',
         ],
+        'cacheFrontend' => [
+            'class' => 'yii\caching\FileCache',
+            'cachePath' => \Yii::getAlias('@frontend') . '/runtime/cache'
+        ],
+        'cacheBackend' => [
+            'class' => 'yii\caching\FileCache',
+            'cachePath' => \Yii::getAlias('@backend') . '/runtime/cache'
+        ],
     ],
 ];


### PR DESCRIPTION
cli command `./yii cache/flush-all` clear only `console/runtime/cache` by default.
`common/config/main.php` not in `console/config/main.php` for clearly and solid one-place configuration of cache
`cacheConsole` is ambiguous, but also can create for use `cacheConsole` from `backend`/`frontend` web apps

Let's discuss!

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | no
| Tests pass?   | yes (fail in php5.5 - I think GD not configured - something like `configure gd --with-png-dir=/usr/include/`: ` [yii\base\InvalidConfigException] Either GD PHP extension with FreeType support or ImageMagick PHP extension with PNG support is required.`)
| Fixed issues  |  [problem details](https://github.com/yiisoft/yii2/issues/5504#issuecomment-58853599); [solution](http://www.yiiframework.com/forum/index.php/topic/61548-how-to-delete-frontend-cache-in-the-backend/page__view__findpost__p__301054)
