### PR TITLE
Specify location of main-local.php to edit

### DIFF
--- a/docs/guide/start-installation.md
+++ b/docs/guide/start-installation.md
@@ -44,7 +44,7 @@ the installed application. You only need to do these once for all.
    /path/to/php-bin/php /path/to/yii-application/init --env=Production --overwrite=All
    ```
 
-2. Create a new database and adjust the `components['db']` configuration in `common/config/main-local.php` accordingly.
+2. Create a new database and adjust the `components['db']` configuration in `/path/to/yii-application/common/config/main-local.php` accordingly.
 
 3. Open a console terminal, apply migrations with command `/path/to/php-bin/php /path/to/yii-application/yii migrate`.
 


### PR DESCRIPTION
I've lost ONE HOUR trying to connect the new installation to the db because I was editing the wrong main-local.php. I was editing the file located in the path C:\MAMP\htdocs\yii2-app-advanced\common\config instead of C:\MAMP\htdocs\yii2-app-advanced\yii-application\common\config