### PR TITLE
Fix #378 restrict phpunit to prevent BC break

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,9 @@
         "yiisoft/yii2-debug": "~2.0.0",
         "yiisoft/yii2-gii": "~2.0.0",
         "yiisoft/yii2-faker": "~2.0.0",
-        "codeception/base": "^2.2.3",
-        "codeception/verify": "~0.3.1"
+        "codeception/base": "^2.4.0",
+        "phpunit/phpunit": "~7.1.0",
+        "codeception/verify": "~1.0.0"
     },
     "config": {
         "process-timeout": 1800,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #378

phpunit 7.2 included some BC breaks so this PR simply prevents the installation of that version.