### PR TITLE
fix support for php 5.4 to 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
         "yiisoft/yii2-debug": "~2.0.0",
         "yiisoft/yii2-gii": "~2.0.0",
         "yiisoft/yii2-faker": "~2.0.0",
-        "codeception/base": "^2.4.0",
-        "phpunit/phpunit": "~7.1.0",
-        "codeception/verify": "~1.0.0"
+        "codeception/base": "^2.2.3",
+        "phpunit/phpunit": "<7.2.0",
+        "codeception/verify": "~0.3.1|~1.0.0"
     },
     "config": {
         "process-timeout": 1800,


### PR DESCRIPTION
dependencies prevented to use those php versions.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes