### PR TITLE
support dash separated params in php init

### DIFF
--- a/init
+++ b/init
@@ -161,7 +161,7 @@ function getParams()
 
     $params = [];
     foreach ($rawParams as $param) {
-        if (preg_match('/^--(\w+)(=(.*))?$/', $param, $matches)) {
+        if (preg_match('/^--([\w-]*\w)(=(.*))?$/', $param, $matches)) {
             $name = $matches[1];
             $params[$name] = isset($matches[3]) ? $matches[3] : true;
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

minor change to support dash separated params in init file.