### PR TITLE
replace document root, fixes #409

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
 FROM yiisoftware/yii2-php:7.2-apache
 
-# Create a symlink for apache (if `/var/www/html` is available)
-RUN rm -rf /var/www/html && ln -s /app/backend/web/ /var/www/html || true
+# Change document root for Apache
+RUN sed -i -e 's|/app/web|/app/backend/web|g' /etc/apache2/sites-available/000-default.conf

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
 FROM yiisoftware/yii2-php:7.2-apache
 
-# Create a symlink for apache (if `/var/www/html` is available)
-RUN rm -rf /var/www/html && ln -s /app/frontend/web/ /var/www/html || true
+# Change document root for Apache
+RUN sed -i -e 's|/app/web|/app/frontend/web|g' /etc/apache2/sites-available/000-default.conf


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | ?
| Fixed issues  | #409 

Linking locations seem to be somehow unreliable, so this PR updates the document root in the image build process.
