### PR TITLE
Make requirements checker return error if there were failed checks

### DIFF
--- a/requirements.php
+++ b/requirements.php
@@ -148,4 +148,8 @@ $requirements = array(
         'memo' => 'PHP mail SMTP server required',
     ),
 );
-$requirementsChecker->checkYii()->check($requirements)->render();
+
+$result = $requirementsChecker->checkYii()->check($requirements)->getResult();
+$requirementsChecker->render();
+
+exit($result['summary']['errors'] === 0 ? 0 : 1);


### PR DESCRIPTION
It is useful in build/deploy/integration procedures in order to stop build process if requirements don’t met.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
