### PR TITLE
Old array syntax in requirement checker (could be run in PHP prior to 5.4)

### DIFF
--- a/requirements.php
+++ b/requirements.php
@@ -14,10 +14,10 @@
 // uncomment and adjust the following line if Yii is not located at the default path
 //$frameworkPath = dirname(__FILE__) . '/vendor/yiisoft/yii2';
 if (!isset($frameworkPath)) {
-    $searchPaths = [
+    $searchPaths = array(
         dirname(__FILE__) . '/vendor/yiisoft/yii2',
         dirname(__FILE__) . '/../../vendor/yiisoft/yii2',
-    ];
+    );
     foreach ($searchPaths as $path) {
         if (is_dir($path)) {
             $frameworkPath = $path;


### PR DESCRIPTION
Same as in https://github.com/yiisoft/yii2-app-basic/pull/201

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
