### PR TITLE
Enabled ConditionalAssretions for Codeception 3.0

### DIFF
--- a/frontend/tests/functional.suite.yml
+++ b/frontend/tests/functional.suite.yml
@@ -4,3 +4,5 @@ modules:
     enabled:
         - Filesystem
         - Yii2
+steps:
+    - Codeception\Step\ConditionalAssertion


### PR DESCRIPTION
Forward compatibility for Codeception 3.0

In next versions of Codeception, conditional assertions will be disabled by default. They make some confusion so far. Differences between of `see` and `canSee` are not clear for most users. So in next version you need to enable this for a config.

This patch should not break current tests.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | https://github.com/Codeception/Codeception/pull/5448
