### PR TITLE
fix nowrap messing with all gridview cells

### DIFF
--- a/backend/web/css/site.css
+++ b/backend/web/css/site.css
@@ -72,7 +72,8 @@ a.desc:after {
     content: "\e156";
 }
 
-.grid-view td {
+.grid-view th,
+.grid-view td:last-child {
     white-space: nowrap;
 }
 


### PR DESCRIPTION
This makes sure that the nowrap is only applied on the last `td` of each row on grid-view, so that action icons dont wrap.
It also ensures sorting icons (up/down arrows) are not wrapped.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
