### PR TITLE
Update codeception/verify to 1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "yiisoft/yii2-faker": "~2.0.0",
         "codeception/base": "^2.4.0",
         "phpunit/phpunit": "~6.5.5",
-        "codeception/verify": "~1.0.0",
+        "codeception/verify": "~1.1.0",
         "symfony/browser-kit": ">=2.7 <=4.2.4"
     },
     "config": {

--- a/frontend/tests/unit/models/ContactFormTest.php
+++ b/frontend/tests/unit/models/ContactFormTest.php
@@ -29,6 +29,6 @@ class ContactFormTest extends \Codeception\Test\Unit
         expect($emailMessage->getFrom())->hasKey('noreply@example.com');
         expect($emailMessage->getReplyTo())->hasKey('tester@example.com');
         expect($emailMessage->getSubject())->equals('very important letter subject');
-        expect($emailMessage->toString())->contains('body of current message');
+        expect($emailMessage->toString())->stringContainsString('body of current message');
     }
 }

--- a/frontend/tests/unit/models/ResendVerificationEmailFormTest.php
+++ b/frontend/tests/unit/models/ResendVerificationEmailFormTest.php
@@ -80,6 +80,6 @@ class ResendVerificationEmailFormTest extends Unit
         expect($mail->getTo())->hasKey('test@mail.com');
         expect($mail->getFrom())->hasKey(\Yii::$app->params['supportEmail']);
         expect($mail->getSubject())->equals('Account registration at ' . \Yii::$app->name);
-        expect($mail->toString())->contains('4ch0qbfhvWwkcuWqjN8SWRq72SOw1KYT_1548675330');
+        expect($mail->toString())->stringContainsString('4ch0qbfhvWwkcuWqjN8SWRq72SOw1KYT_1548675330');
     }
 }

--- a/frontend/tests/unit/models/SignupFormTest.php
+++ b/frontend/tests/unit/models/SignupFormTest.php
@@ -48,7 +48,7 @@ class SignupFormTest extends \Codeception\Test\Unit
         expect($mail->getTo())->hasKey('some_email@example.com');
         expect($mail->getFrom())->hasKey(\Yii::$app->params['supportEmail']);
         expect($mail->getSubject())->equals('Account registration at ' . \Yii::$app->name);
-        expect($mail->toString())->contains($user->verification_token);
+        expect($mail->toString())->stringContainsString($user->verification_token);
     }
 
     public function testNotCorrectSignup()


### PR DESCRIPTION
Update codeception/verify dependency to 1.1.0 and use `stringContainsString()` assertion instead of `contains()`, because `assertContains` with string haystacks is deprecated in PHPUnit 8

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | https://github.com/Codeception/Codeception/pull/5571

Currently 3 tests fail with PHPUnit 8, this change fixes yii2 build in Codeception and allows you to extend supported versions of `codeception/base` up to 3.x and PHPUnit up to 8.x when you are ready for that.
I have no idea why `codeception/base` is restricted to 2.4.x and `phpunit/phpunit` to `~6.5.5`.
