### PR TITLE
Run tests on PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ php:
 # faster builds on new travis setup not using sudo
 sudo: false
 
+services:
+  - mysql
+
 # cache vendor dirs
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "yiisoft/yii2-gii": "~2.1.0",
         "yiisoft/yii2-faker": "~2.0.0",
         "codeception/base": "^2.4.0",
-        "phpunit/phpunit": "~6.5.5",
-        "codeception/verify": "~1.1.0",
+        "phpunit/phpunit": "~5.7.27 || ~6.5.5",
+        "codeception/verify": "~0.5.0 || ~1.1.0",
         "symfony/browser-kit": ">=2.7 <=4.2.4"
     },
     "config": {


### PR DESCRIPTION
I released a version of codeception/verify which runs on PHP 5.6

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #440
