### PR TITLE
Removed username, using email instead of username to login.

### DIFF
--- a/backend/tests/_data/login_data.php
+++ b/backend/tests/_data/login_data.php
@@ -1,7 +1,6 @@
 <?php
 return [
     [
-        'username' => 'erau',
         'auth_key' => 'tUu1qHcde0diwUol3xeI-18MuHkkprQI',
         // password_0
         'password_hash' => '$2y$13$nJ1WDlBaGcbCdbNC5.5l4.sgy.OMEKCqtDQOdQ2OWpgiKRWYyzzne',

--- a/backend/tests/functional/LoginCest.php
+++ b/backend/tests/functional/LoginCest.php
@@ -33,11 +33,11 @@ class LoginCest
     public function loginUser(FunctionalTester $I)
     {
         $I->amOnPage('/site/login');
-        $I->fillField('Username', 'erau');
+        $I->fillField('Email', 'sfriesen@jenkins.info');
         $I->fillField('Password', 'password_0');
         $I->click('login-button');
 
-        $I->see('Logout (erau)', 'form button[type=submit]');
+        $I->see('Logout (sfriesen@jenkins.info)', 'form button[type=submit]');
         $I->dontSeeLink('Login');
         $I->dontSeeLink('Signup');
     }

--- a/backend/views/layouts/main.php
+++ b/backend/views/layouts/main.php
@@ -44,7 +44,7 @@ AppAsset::register($this);
         $menuItems[] = '<li>'
             . Html::beginForm(['/site/logout'], 'post')
             . Html::submitButton(
-                'Logout (' . Yii::$app->user->identity->username . ')',
+                'Logout (' . Yii::$app->user->identity->email . ')',
                 ['class' => 'btn btn-link logout']
             )
             . Html::endForm()

--- a/backend/views/site/login.php
+++ b/backend/views/site/login.php
@@ -19,7 +19,7 @@ $this->params['breadcrumbs'][] = $this->title;
         <div class="col-lg-5">
             <?php $form = ActiveForm::begin(['id' => 'login-form']); ?>
 
-                <?= $form->field($model, 'username')->textInput(['autofocus' => true]) ?>
+                <?= $form->field($model, 'email')->textInput(['autofocus' => true]) ?>
 
                 <?= $form->field($model, 'password')->passwordInput() ?>
 

--- a/common/mail/emailVerify-html.php
+++ b/common/mail/emailVerify-html.php
@@ -7,7 +7,7 @@ use yii\helpers\Html;
 $verifyLink = Yii::$app->urlManager->createAbsoluteUrl(['site/verify-email', 'token' => $user->verification_token]);
 ?>
 <div class="verify-email">
-    <p>Hello <?= Html::encode($user->username) ?>,</p>
+    <p>Hello <?= Html::encode($user->email) ?>,</p>
 
     <p>Follow the link below to verify your email:</p>
 

--- a/common/mail/emailVerify-text.php
+++ b/common/mail/emailVerify-text.php
@@ -5,7 +5,7 @@
 
 $verifyLink = Yii::$app->urlManager->createAbsoluteUrl(['site/verify-email', 'token' => $user->verification_token]);
 ?>
-Hello <?= $user->username ?>,
+Hello <?= $user->email ?>,
 
 Follow the link below to verify your email:
 

--- a/common/mail/passwordResetToken-html.php
+++ b/common/mail/passwordResetToken-html.php
@@ -7,7 +7,7 @@ use yii\helpers\Html;
 $resetLink = Yii::$app->urlManager->createAbsoluteUrl(['site/reset-password', 'token' => $user->password_reset_token]);
 ?>
 <div class="password-reset">
-    <p>Hello <?= Html::encode($user->username) ?>,</p>
+    <p>Hello <?= Html::encode($user->email) ?>,</p>
 
     <p>Follow the link below to reset your password:</p>
 

--- a/common/mail/passwordResetToken-text.php
+++ b/common/mail/passwordResetToken-text.php
@@ -5,7 +5,7 @@
 
 $resetLink = Yii::$app->urlManager->createAbsoluteUrl(['site/reset-password', 'token' => $user->password_reset_token]);
 ?>
-Hello <?= $user->username ?>,
+Hello <?= $user->email ?>,
 
 Follow the link below to reset your password:
 

--- a/common/models/LoginForm.php
+++ b/common/models/LoginForm.php
@@ -9,7 +9,7 @@ use yii\base\Model;
  */
 class LoginForm extends Model
 {
-    public $username;
+    public $email;
     public $password;
     public $rememberMe = true;
 
@@ -22,8 +22,9 @@ class LoginForm extends Model
     public function rules()
     {
         return [
-            // username and password are both required
-            [['username', 'password'], 'required'],
+            // email and password are both required
+            [['email', 'password'], 'required'],
+            ['email', 'email'],
             // rememberMe must be a boolean value
             ['rememberMe', 'boolean'],
             // password is validated by validatePassword()
@@ -43,13 +44,13 @@ class LoginForm extends Model
         if (!$this->hasErrors()) {
             $user = $this->getUser();
             if (!$user || !$user->validatePassword($this->password)) {
-                $this->addError($attribute, 'Incorrect username or password.');
+                $this->addError($attribute, 'Incorrect email or password.');
             }
         }
     }
 
     /**
-     * Logs in a user using the provided username and password.
+     * Logs in a user using the provided email and password.
      *
      * @return bool whether the user is logged in successfully
      */
@@ -63,14 +64,14 @@ class LoginForm extends Model
     }
 
     /**
-     * Finds user by [[username]]
+     * Finds user by [[email]]
      *
      * @return User|null
      */
     protected function getUser()
     {
         if ($this->_user === null) {
-            $this->_user = User::findByUsername($this->username);
+            $this->_user = User::findByEmail($this->email);
         }
 
         return $this->_user;

--- a/common/models/User.php
+++ b/common/models/User.php
@@ -11,7 +11,6 @@ use yii\web\IdentityInterface;
  * User model
  *
  * @property integer $id
- * @property string $username
  * @property string $password_hash
  * @property string $password_reset_token
  * @property string $verification_token
@@ -75,14 +74,14 @@ class User extends ActiveRecord implements IdentityInterface
     }
 
     /**
-     * Finds user by username
+     * Finds user by email
      *
-     * @param string $username
+     * @param string $email
      * @return static|null
      */
-    public static function findByUsername($username)
+    public static function findByEmail($email)
     {
-        return static::findOne(['username' => $username, 'status' => self::STATUS_ACTIVE]);
+        return static::findOne(['email' => $email, 'status' => self::STATUS_ACTIVE]);
     }
 
     /**

--- a/common/tests/_data/user.php
+++ b/common/tests/_data/user.php
@@ -2,7 +2,6 @@
 
 return [
     [
-        'username' => 'bayer.hudson',
         'auth_key' => 'HP187Mvq7Mmm3CTU80dLkGmni_FUH_lR',
         //password_0
         'password_hash' => '$2y$13$EjaPFBnZOQsHdGuHI.xvhuDp1fHpo8hKRSk6yshqa9c5EG8s3C3lO',

--- a/common/tests/unit/models/LoginFormTest.php
+++ b/common/tests/unit/models/LoginFormTest.php
@@ -33,7 +33,7 @@ class LoginFormTest extends \Codeception\Test\Unit
     public function testLoginNoUser()
     {
         $model = new LoginForm([
-            'username' => 'not_existing_username',
+            'email' => 'not_existing_email@dot.com',
             'password' => 'not_existing_password',
         ]);
 
@@ -44,7 +44,7 @@ class LoginFormTest extends \Codeception\Test\Unit
     public function testLoginWrongPassword()
     {
         $model = new LoginForm([
-            'username' => 'bayer.hudson',
+            'email' => 'nicole.paucek@schultz.info',
             'password' => 'wrong_password',
         ]);
 
@@ -56,7 +56,7 @@ class LoginFormTest extends \Codeception\Test\Unit
     public function testLoginCorrect()
     {
         $model = new LoginForm([
-            'username' => 'bayer.hudson',
+            'email' => 'nicole.paucek@schultz.info',
             'password' => 'password_0',
         ]);
 

--- a/console/migrations/m130524_201442_init.php
+++ b/console/migrations/m130524_201442_init.php
@@ -14,7 +14,6 @@ class m130524_201442_init extends Migration
 
         $this->createTable('{{%user}}', [
             'id' => $this->primaryKey(),
-            'username' => $this->string()->notNull()->unique(),
             'auth_key' => $this->string(32)->notNull(),
             'password_hash' => $this->string()->notNull(),
             'password_reset_token' => $this->string()->unique(),

--- a/frontend/models/SignupForm.php
+++ b/frontend/models/SignupForm.php
@@ -10,7 +10,6 @@ use common\models\User;
  */
 class SignupForm extends Model
 {
-    public $username;
     public $email;
     public $password;
 
@@ -21,11 +20,6 @@ class SignupForm extends Model
     public function rules()
     {
         return [
-            ['username', 'trim'],
-            ['username', 'required'],
-            ['username', 'unique', 'targetClass' => '\common\models\User', 'message' => 'This username has already been taken.'],
-            ['username', 'string', 'min' => 2, 'max' => 255],
-
             ['email', 'trim'],
             ['email', 'required'],
             ['email', 'email'],
@@ -49,7 +43,6 @@ class SignupForm extends Model
         }
         
         $user = new User();
-        $user->username = $this->username;
         $user->email = $this->email;
         $user->setPassword($this->password);
         $user->generateAuthKey();

--- a/frontend/tests/_data/login_data.php
+++ b/frontend/tests/_data/login_data.php
@@ -1,7 +1,6 @@
 <?php
 return [
     [
-        'username' => 'erau',
         'auth_key' => 'tUu1qHcde0diwUol3xeI-18MuHkkprQI',
         // password_0
         'password_hash' => '$2y$13$nJ1WDlBaGcbCdbNC5.5l4.sgy.OMEKCqtDQOdQ2OWpgiKRWYyzzne',
@@ -11,7 +10,6 @@ return [
         'email' => 'sfriesen@jenkins.info',
     ],
     [
-        'username' => 'test.test',
         'auth_key' => 'O87GkY3_UfmMHYkyezZ7QLfmkKNsllzT',
         // Test1234
         'password_hash' => 'O87GkY3_UfmMHYkyezZ7QLfmkKNsllzT',

--- a/frontend/tests/_data/user.php
+++ b/frontend/tests/_data/user.php
@@ -2,7 +2,6 @@
 
 return [
     [
-        'username' => 'okirlin',
         'auth_key' => 'iwTNae9t34OmnK6l4vT4IeaTk-YWI2Rv',
         'password_hash' => '$2y$13$CXT0Rkle1EMJ/c1l5bylL.EylfmQ39O5JlHJVFpNn618OUS1HwaIi',
         'password_reset_token' => 't5GU9NwpuGYSfb7FEZMAxqtuz2PkEvv_' . time(),
@@ -11,7 +10,6 @@ return [
         'email' => 'brady.renner@rutherford.com',
     ],
     [
-        'username' => 'troy.becker',
         'auth_key' => 'EdKfXrx88weFMV0vIxuTMWKgfK2tS3Lp',
         'password_hash' => '$2y$13$g5nv41Px7VBqhS3hVsVN2.MKfgT3jFdkXEsMC4rQJLfaMa7VaJqL2',
         'password_reset_token' => '4BSNyiZNAuxjs5Mty990c47sVrgllIi_' . time(),
@@ -21,7 +19,6 @@ return [
         'status' => '0',
     ],
     [
-        'username' => 'test.test',
         'auth_key' => 'O87GkY3_UfmMHYkyezZ7QLfmkKNsllzT',
         //Test1234
         'password_hash' => '$2y$13$d17z0w/wKC4LFwtzBcmx6up4jErQuandJqhzKGKczfWuiEhLBtQBK',
@@ -32,7 +29,6 @@ return [
         'verification_token' => '4ch0qbfhvWwkcuWqjN8SWRq72SOw1KYT_1548675330',
     ],
     [
-        'username' => 'test2.test',
         'auth_key' => '4XXdVqi3rDpa_a6JH6zqVreFxUPcUPvJ',
         //Test1234
         'password_hash' => '$2y$13$d17z0w/wKC4LFwtzBcmx6up4jErQuandJqhzKGKczfWuiEhLBtQBK',

--- a/frontend/tests/functional/LoginCest.php
+++ b/frontend/tests/functional/LoginCest.php
@@ -32,7 +32,7 @@ class LoginCest
     protected function formParams($login, $password)
     {
         return [
-            'LoginForm[username]' => $login,
+            'LoginForm[email]' => $login,
             'LoginForm[password]' => $password,
         ];
     }
@@ -40,26 +40,26 @@ class LoginCest
     public function checkEmpty(FunctionalTester $I)
     {
         $I->submitForm('#login-form', $this->formParams('', ''));
-        $I->seeValidationError('Username cannot be blank.');
+        $I->seeValidationError('Email cannot be blank.');
         $I->seeValidationError('Password cannot be blank.');
     }
 
     public function checkWrongPassword(FunctionalTester $I)
     {
-        $I->submitForm('#login-form', $this->formParams('admin', 'wrong'));
-        $I->seeValidationError('Incorrect username or password.');
+        $I->submitForm('#login-form', $this->formParams('admin@dot.com', 'wrong'));
+        $I->seeValidationError('Incorrect email or password.');
     }
 
     public function checkInactiveAccount(FunctionalTester $I)
     {
-        $I->submitForm('#login-form', $this->formParams('test.test', 'Test1234'));
-        $I->seeValidationError('Incorrect username or password');
+        $I->submitForm('#login-form', $this->formParams('test@mail.com', 'Test1234'));
+        $I->seeValidationError('Incorrect email or password');
     }
 
     public function checkValidLogin(FunctionalTester $I)
     {
-        $I->submitForm('#login-form', $this->formParams('erau', 'password_0'));
-        $I->see('Logout (erau)', 'form button[type=submit]');
+        $I->submitForm('#login-form', $this->formParams('sfriesen@jenkins.info', 'password_0'));
+        $I->see('Logout (sfriesen@jenkins.info)', 'form button[type=submit]');
         $I->dontSeeLink('Login');
         $I->dontSeeLink('Signup');
     }

--- a/frontend/tests/functional/ResendVerificationEmailCest.php
+++ b/frontend/tests/functional/ResendVerificationEmailCest.php
@@ -75,7 +75,6 @@ class ResendVerificationEmailCest
         $I->canSeeEmailIsSent();
         $I->seeRecord('common\models\User', [
             'email' => 'test@mail.com',
-            'username' => 'test.test',
             'status' => \common\models\User::STATUS_INACTIVE
         ]);
         $I->see('Check your email for further instructions.');

--- a/frontend/tests/functional/SignupCest.php
+++ b/frontend/tests/functional/SignupCest.php
@@ -19,7 +19,7 @@ class SignupCest
         $I->see('Signup', 'h1');
         $I->see('Please fill out the following fields to signup:');
         $I->submitForm($this->formId, []);
-        $I->seeValidationError('Username cannot be blank.');
+        $I->seeValidationError('Email cannot be blank.');
         $I->seeValidationError('Email cannot be blank.');
         $I->seeValidationError('Password cannot be blank.');
 
@@ -29,12 +29,10 @@ class SignupCest
     {
         $I->submitForm(
             $this->formId, [
-            'SignupForm[username]'  => 'tester',
             'SignupForm[email]'     => 'ttttt',
             'SignupForm[password]'  => 'tester_password',
         ]
         );
-        $I->dontSee('Username cannot be blank.', '.help-block');
         $I->dontSee('Password cannot be blank.', '.help-block');
         $I->see('Email is not a valid email address.', '.help-block');
     }
@@ -42,13 +40,11 @@ class SignupCest
     public function signupSuccessfully(FunctionalTester $I)
     {
         $I->submitForm($this->formId, [
-            'SignupForm[username]' => 'tester',
             'SignupForm[email]' => 'tester.email@example.com',
             'SignupForm[password]' => 'tester_password',
         ]);
 
         $I->seeRecord('common\models\User', [
-            'username' => 'tester',
             'email' => 'tester.email@example.com',
             'status' => \common\models\User::STATUS_INACTIVE
         ]);

--- a/frontend/tests/functional/VerifyEmailCest.php
+++ b/frontend/tests/functional/VerifyEmailCest.php
@@ -57,10 +57,9 @@ class VerifyEmailCest
         $I->amOnRoute('site/verify-email', ['token' => '4ch0qbfhvWwkcuWqjN8SWRq72SOw1KYT_1548675330']);
         $I->canSee('Your email has been confirmed!');
         $I->canSee('Congratulations!', 'h1');
-        $I->see('Logout (test.test)', 'form button[type=submit]');
+        $I->see('Logout (test@mail.com)', 'form button[type=submit]');
 
         $I->seeRecord('common\models\User', [
-           'username' => 'test.test',
            'email' => 'test@mail.com',
            'status' => \common\models\User::STATUS_ACTIVE
         ]);

--- a/frontend/tests/unit/models/SignupFormTest.php
+++ b/frontend/tests/unit/models/SignupFormTest.php
@@ -25,7 +25,6 @@ class SignupFormTest extends \Codeception\Test\Unit
     public function testCorrectSignup()
     {
         $model = new SignupForm([
-            'username' => 'some_username',
             'email' => 'some_email@example.com',
             'password' => 'some_password',
         ]);
@@ -35,7 +34,6 @@ class SignupFormTest extends \Codeception\Test\Unit
 
         /** @var \common\models\User $user */
         $user = $this->tester->grabRecord('common\models\User', [
-            'username' => 'some_username',
             'email' => 'some_email@example.com',
             'status' => \common\models\User::STATUS_INACTIVE
         ]);
@@ -54,17 +52,13 @@ class SignupFormTest extends \Codeception\Test\Unit
     public function testNotCorrectSignup()
     {
         $model = new SignupForm([
-            'username' => 'troy.becker',
             'email' => 'nicolas.dianna@hotmail.com',
             'password' => 'some_password',
         ]);
 
         expect_not($model->signup());
-        expect_that($model->getErrors('username'));
         expect_that($model->getErrors('email'));
 
-        expect($model->getFirstError('username'))
-            ->equals('This username has already been taken.');
         expect($model->getFirstError('email'))
             ->equals('This email address has already been taken.');
     }

--- a/frontend/tests/unit/models/VerifyEmailFormTest.php
+++ b/frontend/tests/unit/models/VerifyEmailFormTest.php
@@ -47,7 +47,6 @@ class VerifyEmailFormTest extends \Codeception\Test\Unit
         $user = $model->verifyEmail();
         expect($user)->isInstanceOf('common\models\User');
 
-        expect($user->username)->equals('test.test');
         expect($user->email)->equals('test@mail.com');
         expect($user->status)->equals(\common\models\User::STATUS_ACTIVE);
         expect($user->validatePassword('Test1234'))->true();

--- a/frontend/views/layouts/main.php
+++ b/frontend/views/layouts/main.php
@@ -47,7 +47,7 @@ AppAsset::register($this);
         $menuItems[] = '<li>'
             . Html::beginForm(['/site/logout'], 'post')
             . Html::submitButton(
-                'Logout (' . Yii::$app->user->identity->username . ')',
+                'Logout (' . Yii::$app->user->identity->email . ')',
                 ['class' => 'btn btn-link logout']
             )
             . Html::endForm()

--- a/frontend/views/site/login.php
+++ b/frontend/views/site/login.php
@@ -19,7 +19,7 @@ $this->params['breadcrumbs'][] = $this->title;
         <div class="col-lg-5">
             <?php $form = ActiveForm::begin(['id' => 'login-form']); ?>
 
-                <?= $form->field($model, 'username')->textInput(['autofocus' => true]) ?>
+                <?= $form->field($model, 'email')->textInput(['autofocus' => true]) ?>
 
                 <?= $form->field($model, 'password')->passwordInput() ?>
 

--- a/frontend/views/site/signup.php
+++ b/frontend/views/site/signup.php
@@ -19,9 +19,7 @@ $this->params['breadcrumbs'][] = $this->title;
         <div class="col-lg-5">
             <?php $form = ActiveForm::begin(['id' => 'form-signup']); ?>
 
-                <?= $form->field($model, 'username')->textInput(['autofocus' => true]) ?>
-
-                <?= $form->field($model, 'email') ?>
+                <?= $form->field($model, 'email')->textInput(['autofocus' => true]) ?>
 
                 <?= $form->field($model, 'password')->passwordInput() ?>
 


### PR DESCRIPTION
Hi!

I always use your template when start new project with Yii. I think it is really great. The only issue I'm always having is that all of my apps never use username neither for user registration nor for authentication. The email is only used. Everytime I need to remove this functionality. So I decided to fork your project with removed username and email used instead to login. Maybe you would like to review this fork or any similar if there's such to be merged in your project. Otherwise maybe it would be useful to leave it here open in case any other developers use your template same way as I do.  

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
