### PR TITLE
Remove version restriction for PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "codeception/module-asserts": "^1.0",
         "codeception/module-yii2": "^1.0",
         "codeception/module-filesystem": "^1.0",
-        "phpunit/phpunit": "~5.7.27 || ~6.5.5",
         "codeception/verify": "~0.5.0 || ~1.1.0",
         "symfony/browser-kit": ">=2.7 <=4.2.4"
     },


### PR DESCRIPTION
This change allows to use PHPUnit 7 and 8 with Yii2-app-advanced template.

This template does not use PHPUnit directly, 
it uses Codeception and it is responsibility of Codeception to manage compatibility with PHPUnit.
Also there is no such restriction in basic app.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | N/A
