### PR TITLE
Add missing class to urlManagerFrontend

### DIFF
--- a/docs/guide/topic-link-backend-frontend.md
+++ b/docs/guide/topic-link-backend-frontend.md
@@ -11,6 +11,7 @@ return [
             // here is your normal backend url manager config
         ],
         'urlManagerFrontend' => [
+            'class' => 'yii\web\UrlManager',        // class is required on custom named url managers!
             // here is your frontend URL manager config
         ],
 


### PR DESCRIPTION
On custom named url managers, the `class` element is required. You will get a `Invalid Configuration` exception without it!

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes (its a doc edit lol)
| Fixed issues  | #466 
