### PR TITLE
Add more detail to docs guide: topic-link-backend-frontend.md

### DIFF
--- a/docs/guide/topic-link-backend-frontend.md
+++ b/docs/guide/topic-link-backend-frontend.md
@@ -29,7 +29,7 @@ You may need to generate links to the frontend or any another app (ie: [topic-ad
 return [
     'components' => [
         'urlManager' => [
-            // here is your normal backend url manager config
+            // here is your normal backend URL manager config
         ],
         'urlManagerFrontend' => [
             'class' => 'yii\web\UrlManager',        // class is required on custom named url managers!

--- a/docs/guide/topic-link-backend-frontend.md
+++ b/docs/guide/topic-link-backend-frontend.md
@@ -32,7 +32,7 @@ return [
             // here is your normal backend URL manager config
         ],
         'urlManagerFrontend' => [
-            'class' => 'yii\web\UrlManager',        // class is required on custom named url managers!
+            'class' => 'yii\web\UrlManager',        // class is required on custom named URL managers!
             'hostInfo' => 'https://example.com',    // the full base domain name to use for the links
             // here is your frontend URL manager config
         ],

--- a/docs/guide/topic-link-backend-frontend.md
+++ b/docs/guide/topic-link-backend-frontend.md
@@ -205,7 +205,7 @@ return [
     // ...
     'components' => [
         'urlManager' => [
-            // backend url manager
+            // backend URL manager
             'enablePrettyUrl' => true,
             'showScriptName' => false,
             'rules' => require Yii::getAlias('@common/config/rules/backend-rules.php'),

--- a/docs/guide/topic-link-backend-frontend.md
+++ b/docs/guide/topic-link-backend-frontend.md
@@ -12,6 +12,7 @@ return [
         ],
         'urlManagerFrontend' => [
             'class' => 'yii\web\UrlManager',        // class is required on custom named url managers!
+            'hostInfo' => 'https://example.com',    // the full base domain name to use for the links
             // here is your frontend URL manager config
         ],
 
@@ -19,22 +20,80 @@ return [
 ];
 ```
 
-After it is done, you can get an URL pointing to frontend like the following:
+The URL Manager doesn't magically know the root url of another app on another sub-domain. This is where the `hostInfo` param
+comes in. It defines the full domain for the URL manager to generate absolute links with.
+
+You may need to generate links to the frontend or any another app (ie: [topic-adding-more-apps.md](https://github.com/yiisoft/yii2-app-advanced/blob/master/docs/guide/topic-adding-more-apps.md)). You can have multiple URL managers for multiple apps on multiple sub-domains.
+
+```php
+return [
+    'components' => [
+        'urlManager' => [
+            // here is your normal backend url manager config
+        ],
+        'urlManagerFrontend' => [
+            'class' => 'yii\web\UrlManager',        // class is required on custom named url managers!
+            'hostInfo' => 'https://example.com',    // the full base domain name to use for the links
+            // here is your frontend URL manager config
+        ],
+        'urlManagerBlog' => [
+            'class' => 'yii\web\UrlManager',            // class is required on custom named url managers!
+            'hostInfo' => 'https://blog.example.com',   // the full base domain name to use for the links
+            // here is your blog URL manager config
+        ],
+
+    ],
+];
+```
+
+After it is done, you can get a URL pointing to the frontend like the following:
 
 ```php
 echo Yii::$app->urlManagerFrontend->createAbsoluteUrl(...);
 ```
 
-In order not to copy-paste frontend rules you may first move these into separate `urls.php` file:
+When you have custom rules that need to be repeated across multiple apps, you should place them in their
+own "rules" files. This way, when you need to make a change, you only need to modify one file.
+
+In the `common/config` directory, create a new folder named `rules`. This will house all of your URL manager rules.
+
+Then create a file named `backend-rules.php` and another named `frontend-rules.php`.
+
+If the respective app doesn't have/need any rules, just have the rules file return an empty array.
+
+```php
+<?php
+return [];
+```
+
+Here is an example of what it looks like with some custom rules:
+
+```php
+<?php
+return [
+    'aff/<id:\d+>' => 'affiliate/index',
+    'lp/<id:\d+>' => 'landing/index',
+];
+```
+
+Now just include/require the respective rules files for the corresponding URL managers:
 
 ```php
 return [
     // ...
     'components' => [
         'urlManager' => [
+            // backend url manager
             'enablePrettyUrl' => true,
             'showScriptName' => false,
-            'rules' => require 'urls.php',
+            'rules' => require Yii::getAlias('@common/config/rules/backend-rules.php'),
+        ],
+        'urlManagerFrontend' => [
+            'class' => 'yii\web\UrlManager',        // class is required on custom named url managers!
+            'hostInfo' => 'https://example.com',    // the full base domain name to use for the links
+            'enablePrettyUrl' => true,
+            'showScriptName' => false,
+            'rules' => require Yii::getAlias('@common/config/rules/frontend-rules.php'),
         ],
         // ...
 
@@ -43,4 +102,124 @@ return [
 ];
 ```
 
-After then you may include it in `urlManagerFrontend` rules as well.
+## Hardcoded hostInfo URL
+
+The examples above are to illustrate what is expected in the field. `hostInfo` expects a full domain name like `https://example.com` or
+`https://backend.example.com`. Having a hard-coded domain in your config isn't very practical. Especially for handling multiple environments
+(local, staging, production, etc).
+
+There are a few ways you can do this. The following way allows you to make use of Yii's environments and the `init` process.
+
+We first need to load functions early on during Composer's autoload.
+
+In your `composer.json` file, add the following:
+
+```json
+"autoload": {
+    "files": [
+        "common/functions.php"
+    ]
+}
+```
+
+Now create `common/functions.php`:
+
+```php
+<?php
+/**
+ * Requires `define('USE_HTTPS', true)` to be in your `index.php` file!
+ */
+function getUrlScheme()
+{
+    return (USE_HTTPS === true) ? 'https' : 'http';
+}
+
+/**
+ * Requires `define('DOMAIN_NAME', 'example.tld')` to be in your `index.php` file!
+ */
+function getDomain($subDomain = null)
+{
+    $sub = $subDomain ? $subDomain . '.' : '';
+    return getUrlScheme() . '://' . $sub . DOMAIN_NAME;
+}
+```
+
+Now we need to define our constants in the corresponding `web/index.php` files. Here are the paths for the default environments.
+
+```
+environments/dev/backend/web/index.php
+environments/dev/frontend/web/index.php
+environments/prod/backend/web/index.php
+environments/prod/frontend/web/index.php
+```
+
+In the `dev` copies, we will use our local development domain name (ie: mylocalsite.test) and in the `prod` copies we will use the real domain (ie: realsite.com).
+
+Add to the top of the index files:
+
+**environments/dev/backend/web/index.php**
+
+```php
+define('USE_HTTPS', true);
+define('DOMAIN_NAME', 'mylocalsite.test');
+```
+
+**environments/dev/frontend/web/index.php**
+
+```php
+define('USE_HTTPS', true);
+define('DOMAIN_NAME', 'mylocalsite.test');
+```
+
+**environments/prod/backend/web/index.php**
+
+```php
+define('USE_HTTPS', true);
+define('DOMAIN_NAME', 'realsite.com');
+```
+
+**environments/prod/frontend/web/index.php**
+
+```php
+define('USE_HTTPS', true);
+define('DOMAIN_NAME', 'realsite.com');
+```
+
+Run `./init` and initialize the proper environment to overwrite the changes.
+
+We can use the functions directly, or create aliases. Let's create aliases.
+
+Add the following in `common/config/bootstrap.php`:
+
+```php
+Yii::setAlias('@frontendDomain', getDomain());              // ex: https://somedomain.tld
+Yii::setAlias('@backendDomain', getDomain('backend'));      // ex: https://backend.somedomain.tld
+```
+
+Remember `www` is a sub-domain, so pass it like one if you use it like so: `getDomain('www')`
+
+Lastly, with all of that set up, you can simply use the aliases in your main config files:
+
+```php
+return [
+    // ...
+    'components' => [
+        'urlManager' => [
+            // backend url manager
+            'enablePrettyUrl' => true,
+            'showScriptName' => false,
+            'rules' => require Yii::getAlias('@common/config/rules/backend-rules.php'),
+        ],
+        'urlManagerFrontend' => [
+            'class' => 'yii\web\UrlManager',        // class is required on custom named url managers!
+            'hostInfo' => Yii::getAlias('@frontendDomain'),    // the full base domain name to use for the links
+            'enablePrettyUrl' => true,
+            'showScriptName' => false,
+            'rules' => require Yii::getAlias('@common/config/rules/frontend-rules.php'),
+        ],
+        // ...
+
+    ],
+    // ...
+];
+```

--- a/docs/guide/topic-link-backend-frontend.md
+++ b/docs/guide/topic-link-backend-frontend.md
@@ -37,7 +37,7 @@ return [
             // here is your frontend URL manager config
         ],
         'urlManagerBlog' => [
-            'class' => 'yii\web\UrlManager',            // class is required on custom named url managers!
+            'class' => 'yii\web\UrlManager',            // class is required on custom named URL managers!
             'hostInfo' => 'https://blog.example.com',   // the full base domain name to use for the links
             // here is your blog URL manager config
         ],

--- a/docs/guide/topic-link-backend-frontend.md
+++ b/docs/guide/topic-link-backend-frontend.md
@@ -23,7 +23,7 @@ return [
 The URL Manager doesn't magically know the root URL of another app on another sub-domain. This is where the `hostInfo` param
 comes in. It defines the full domain for the URL manager to generate absolute links with.
 
-You may need to generate links to the frontend or any another app (ie: [topic-adding-more-apps.md](https://github.com/yiisoft/yii2-app-advanced/blob/master/docs/guide/topic-adding-more-apps.md)). You can have multiple URL managers for multiple apps on multiple sub-domains.
+You may need to generate links to the frontend or any another app (ie: [topic-adding-more-apps.md](topic-adding-more-apps.md)). You can have multiple URL managers for multiple apps on multiple sub-domains.
 
 ```php
 return [

--- a/docs/guide/topic-link-backend-frontend.md
+++ b/docs/guide/topic-link-backend-frontend.md
@@ -83,7 +83,7 @@ return [
     // ...
     'components' => [
         'urlManager' => [
-            // backend url manager
+            // backend URL manager
             'enablePrettyUrl' => true,
             'showScriptName' => false,
             'rules' => require Yii::getAlias('@common/config/rules/backend-rules.php'),

--- a/docs/guide/topic-link-backend-frontend.md
+++ b/docs/guide/topic-link-backend-frontend.md
@@ -20,7 +20,7 @@ return [
 ];
 ```
 
-The URL Manager doesn't magically know the root url of another app on another sub-domain. This is where the `hostInfo` param
+The URL Manager doesn't magically know the root URL of another app on another sub-domain. This is where the `hostInfo` param
 comes in. It defines the full domain for the URL manager to generate absolute links with.
 
 You may need to generate links to the frontend or any another app (ie: [topic-adding-more-apps.md](https://github.com/yiisoft/yii2-app-advanced/blob/master/docs/guide/topic-adding-more-apps.md)). You can have multiple URL managers for multiple apps on multiple sub-domains.

--- a/docs/guide/topic-link-backend-frontend.md
+++ b/docs/guide/topic-link-backend-frontend.md
@@ -153,7 +153,7 @@ environments/prod/backend/web/index.php
 environments/prod/frontend/web/index.php
 ```
 
-In the `dev` copies, we will use our local development domain name (ie: mylocalsite.test) and in the `prod` copies we will use the real domain (ie: realsite.com).
+In the `dev` copies, we will use our local development domain name (ie: mylocalsite.test) and in the `prod` copies we will use the real domain (ie: example.com).
 
 Add to the top of the index files:
 
@@ -175,14 +175,14 @@ define('DOMAIN_NAME', 'mylocalsite.test');
 
 ```php
 define('USE_HTTPS', true);
-define('DOMAIN_NAME', 'realsite.com');
+define('DOMAIN_NAME', 'example.com');
 ```
 
 **environments/prod/frontend/web/index.php**
 
 ```php
 define('USE_HTTPS', true);
-define('DOMAIN_NAME', 'realsite.com');
+define('DOMAIN_NAME', 'example.com');
 ```
 
 Run `./init` and initialize the proper environment to overwrite the changes.

--- a/docs/guide/topic-link-backend-frontend.md
+++ b/docs/guide/topic-link-backend-frontend.md
@@ -211,7 +211,7 @@ return [
             'rules' => require Yii::getAlias('@common/config/rules/backend-rules.php'),
         ],
         'urlManagerFrontend' => [
-            'class' => 'yii\web\UrlManager',        // class is required on custom named url managers!
+            'class' => 'yii\web\UrlManager',        // class is required on custom named URL managers!
             'hostInfo' => Yii::getAlias('@frontendDomain'),    // the full base domain name to use for the links
             'enablePrettyUrl' => true,
             'showScriptName' => false,


### PR DESCRIPTION
As requested, here is a PR for going into more detail on the docs guide "topic-link-backend-frontend".

Let me know if you need anything changed. Feel free to modify it... or toss it out :)

@samdark and I discussed this in #466 

He mentioned using "params", however they are not available yet in the config array. (I tried first just to be sure)

The extra steps are necessary to limit "hard coding" the domain/urls. This method utilizes Yii2's environments to dynamically change the domain name based on the environment. Aliases are then created so the generation is only done once. Not that the functions do anything resource intensive, but aliases are cleaner and easier for the end user to remember in case they want to reference those URLs anywhere else later via `Yii::getAlias('@frontendDomain')`.

Also, in regards to the `rules` config param, using `urls.php` seems to be the incorrect terminology. They aren't actually urls. They are rules.

The existing docs don't make sense here either. If we are in `backend` and create a `urls.php` file for the `frontendUrlManager`, the file exists in `backend`. Well, `frontend` on it's `urlManager` would either need to cross-link across to pull it from the `backend` or have it's own duplicate and redundant `urls.php` file in `frontend` as well.

So the cleanest solution is to place ALL of the rules in `common/config/rules` and named respectively (ie: `frontend-rules.php`, `backend-rules.php`, etc).

I am open to modifying this however you see fit. I just wanted to throw this up so we can discuss/review it.