### PR TITLE
Enh: Add virtual machine IP to the Yii2 Advanced "allowedIPs"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,7 +68,7 @@ Vagrant.configure(2) do |config|
   config.hostmanager.aliases            = domains.values
 
   # provisioners
-  config.vm.provision 'shell', path: './vagrant/provision/once-as-root.sh', args: [options['timezone']]
+  config.vm.provision 'shell', path: './vagrant/provision/once-as-root.sh', args: [options['timezone'], options['ip']]
   config.vm.provision 'shell', path: './vagrant/provision/once-as-vagrant.sh', args: [options['github_token']], privileged: false
   config.vm.provision 'shell', path: './vagrant/provision/always-as-root.sh', run: 'always'
 

--- a/vagrant/provision/once-as-root.sh
+++ b/vagrant/provision/once-as-root.sh
@@ -5,6 +5,7 @@ source /app/vagrant/provision/common.sh
 #== Import script args ==
 
 timezone=$(echo "$1")
+readonly IP=$2
 
 #== Provision script ==
 
@@ -14,6 +15,9 @@ export DEBIAN_FRONTEND=noninteractive
 
 info "Configure timezone"
 timedatectl set-timezone ${timezone} --no-ask-password
+
+info "AWK initial replacement work"
+awk -v ip=$IP -f /app/vagrant/provision/provision.awk /app/environments/dev/*end/config/main-local.php
 
 info "Prepare root password for MySQL"
 debconf-set-selections <<< "mysql-community-server mysql-community-server/root-pass password \"''\""

--- a/vagrant/provision/provision.awk
+++ b/vagrant/provision/provision.awk
@@ -1,0 +1,70 @@
+###
+# Modifying Yii2's files for initialize Vagrant VM
+#
+# @author HA3IK <golubha3ik@gmail.com>
+# @version 1.0.0
+
+BEGIN {
+    print "AWK BEGINs its work:"
+    IGNORECASE = 1
+    # Correct IP - wildcard last octet
+    match(ip, /(([0-9]+\.)+)/, arr)
+    ip = arr[1] "*"
+}
+BEGINFILE {
+    msg = "- Work with: " FILENAME
+    # Define array index for the file
+    switch (FILENAME) {
+    case /environments\/dev\/(back|front)end\/config\/main\-local\.php$/:
+        isFile["IsMainLocConf"] = 1
+        msg = msg " - allow VM IP for Gii and debug toolbar"
+        break
+    }
+    # Print the final message
+    print msg
+}
+# BODY
+{
+    # IF environments/dev/(back|front)end/config/main-local.php
+    if (isFile["IsMainLocConf"]) {
+        # IF the line[s] after yii\(debug|gii)\Module
+        if (FNR == nextLine["nubmer"]) {
+            # Prepare for next line
+            ++nextLine["nubmer"]
+            # IF line has "allowedIPs"
+            if (index($0, "allowedIPs")) {
+                # IF our IP is not there
+                if (!index($0, ip)) {
+                    # Add it
+                    match($0, /([^\]]+)(.+)/, arr)
+                    $0 = sprintf("%s, '%s'%s", arr[1], ip, arr[2])
+                }
+                # Delete next line
+                delete nextLine
+            # IF "allowedIPs" are not set - search for the end of an array structure
+            } else if ($0 ~ /\];$/) {
+                # Rewrite line
+                $0 = nextLine["indent"] "'allowedIPs' => ['127.0.0.1', '::1', '" ip "'],\n" $0
+                delete nextLine
+            }
+            # IF line is done
+            if (!length(nextLine)) {
+                printf "  Line %d: Allowed IP: %s\n", FNR, ip
+            }
+        # Search for yii\(debug|gii)\Module
+        } else if (match($0, /^(\s+).+yii\\(debug|gii)\\Module/, arr)) {
+            # Save next line and indent
+            nextLine["nubmer"] = FNR + 1
+            nextLine["indent"] = arr[1]
+        }
+        # Rewrite the file
+        print $0 > FILENAME
+    }
+}
+ENDFILE {
+    delete isFile
+    close(FILENAME)
+}
+END {
+    print "AWK ENDs its work."
+}


### PR DESCRIPTION
Vagrant's virtual machine IP is not in the `allowedIPs` lists for "Gii" and "debug toolbar".
By default, Yii2's Vagrant CIDR notation is 192.168.83.137/24, so we convert it to 192.168.83.* then add to each of the `allowedIPs` lists in the "environments/dev/***end**/config/main-local.php" files.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | 
