### PR TITLE
Enh: Vagrant plugin[s] installation nonstop

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,20 @@
 require 'yaml'
 require 'fileutils'
 
+required_plugins_installed = nil
 required_plugins = %w( vagrant-hostmanager vagrant-vbguest )
 required_plugins.each do |plugin|
-    exec "vagrant plugin install #{plugin}" unless Vagrant.has_plugin? plugin
+  unless Vagrant.has_plugin? plugin
+    system "vagrant plugin install #{plugin}"
+    required_plugins_installed = true
+  end
+end
+
+# IF plugin[s] was just installed - restart required
+if required_plugins_installed
+  # Get CLI command[s] and call again
+  system 'vagrant' + ARGV.to_s.gsub(/\[\"|\", \"|\"\]/, ' ')
+  exit
 end
 
 domains = {


### PR DESCRIPTION
If `required_plugins` were not installed, the Vagrant any call process will stop after the installation of each of them.
_It's good that there only two required plugins - three launches, and we will reach the goal!_ 😅
Now it's fixed and Vagrant startup process doesn't stop.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | 
