### PR TITLE
Fix namespaces in IDE for codeception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,13 @@
         "codeception/verify": "^2.2",
         "symfony/browser-kit": "^6.0 || >=2.7 <=4.2.4"
     },
+    "autoload-dev": {
+        "psr-4": {
+            "common\\tests\\": ["common/tests/", "common/tests/_support"],
+            "backend\\tests\\": ["backend/tests/", "backend/tests/_support"],
+            "frontend\\tests\\": ["frontend/tests/", "frontend/tests/_support"]
+        }
+    },
     "config": {
         "allow-plugins": {
             "yiisoft/yii2-composer" : true


### PR DESCRIPTION
Fix a small annoyance in PHPStorm where the generated files from codeception are not under the accurate namespace:

<img width="786" alt="Screen Shot 2022-09-19 at 8 38 29 AM" src="https://user-images.githubusercontent.com/304450/190970895-60734a58-0f5b-4b36-b2f0-cd1ee18bf978.png">

This adds the `_support` folder into the relevant namespace

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
